### PR TITLE
fix queue not clearing after persisting buildings

### DIFF
--- a/src/store/upgrade.js
+++ b/src/store/upgrade.js
@@ -324,6 +324,7 @@ export default {
         },
         makePersistent({ state, rootState, commit, dispatch }, name) {
             const upgrade = state.item[name];
+            const level = upgrade.level;
             commit('updateKey', {name, key: 'persistent', value: true});
 
             const subfeature = rootState.system.features[upgrade.feature]?.currentSubfeature;
@@ -332,10 +333,10 @@ export default {
             }
 
             // Cleanup the build queue if needed
-            if (upgrade.mode === 'queue' && upgrade.bought > upgrade.level) {
+            if (upgrade.mode === 'queue' && upgrade.bought > level) {
                 const queueKey = `${upgrade.feature}_${upgrade.type}`;
                 let newQueue = [...state.queue[queueKey]];
-                for (let i = 0, n = upgrade.highestLevel - upgrade.level; i < n; i++) {
+                for (let i = 0, n = upgrade.highestLevel - level; i < n; i++) {
                     const index = newQueue.findIndex(elem => elem === name);
                     if (index !== -1) {
                         newQueue.splice(index, 1);


### PR DESCRIPTION
* compare new upgrade.bought with old upgrade.level when cleaning up queue after applying persistence
* add test case that (hopefully!) expresses the issue correctly; it fails without the change to `src/store/upgrade.js`
** I'm happy to make changes to the test as it feels a bit ugly right now