### PR TITLE
Fix search for inventory flower to sell in bloom event

### DIFF
--- a/src/js/modules/event/bloom/tick.js
+++ b/src/js/modules/event/bloom/tick.js
@@ -42,10 +42,10 @@ function breedFlower(breeder, amount = 1) {
                 store.dispatch('note/find', 'event_12');
             } else {
                 // Try to find a worse flower and sell it
-                let slotTier = -1;
+                let slotTier = tier;
                 let slotToSell = null;
                 store.state.bloom.inventory.forEach((invFlower, slot) => {
-                    if (flower === invFlower.type && tier > invFlower.tier && (invFlower.tier > slotTier)) {
+                    if (flower === invFlower.type && invFlower.tier < slotTier) {
                         slotTier = invFlower.tier;
                         slotToSell = slot;
                     }


### PR DESCRIPTION
The existing search for a lower-tier flower of the same type, to sell in case the inventory is full, was faulty and picked the best flower worse than the new flower.