### PR TITLE
Add stat breakdown to mining2 resources tooltip

### DIFF
--- a/src/components/partial/mining/Status.vue
+++ b/src/components/partial/mining/Status.vue
@@ -146,6 +146,10 @@
               <currency-icon :name="`mining_${gas}`"></currency-icon>
               <span>{{ $vuetify.lang.t(`$vuetify.mining.gasGain.3`) }}</span>
             </div>
+            <div class="text-center">{{ $vuetify.lang.t('$vuetify.gooboo.gain') }}</div>
+            <stat-breakdown :name="`currencyMining${ gas.charAt(0).toUpperCase() + gas.slice(1) }Gain`"></stat-breakdown>
+            <div class="text-center">{{ $vuetify.lang.t('$vuetify.mult.currencyMining' + gas.charAt(0).toUpperCase() + gas.slice(1) + 'Increment') }}</div>
+            <stat-breakdown :base="1" :name="`currencyMining${ gas.charAt(0).toUpperCase() + gas.slice(1) }Increment`"></stat-breakdown>
           </gb-tooltip>
         </template>
       </template>

--- a/src/components/partial/mining/Status.vue
+++ b/src/components/partial/mining/Status.vue
@@ -118,10 +118,16 @@
         </gb-tooltip>
       </template>
       <template v-else-if="subfeature === 1">
-        <v-chip v-if="smoke > 0" label class="balloon-text-dynamic ma-1" :class="$vuetify.theme.dark ? 'darken-2' : 'lighten-2'" :color="currency.mining_smoke.color">
-          <v-icon class="mr-2">{{ currency.mining_smoke.icon }}</v-icon>
-          <span>{{ $formatNum(smoke, true) }}</span>
-        </v-chip>
+        <gb-tooltip key="status-smoke" v-if="smoke > 0" :title-text="$vuetify.lang.t('$vuetify.currency.mining_smoke.name')">
+          <template v-slot:activator="{ on, attrs }">
+            <v-chip label class="balloon-text-dynamic ma-1" :class="$vuetify.theme.dark ? 'darken-2' : 'lighten-2'" :color="currency.mining_smoke.color" v-bind="attrs" v-on="on">
+              <v-icon class="mr-2">{{ currency.mining_smoke.icon }}</v-icon>
+              <span>{{ $formatNum(smoke, true) }}</span>
+            </v-chip>
+          </template>
+          <div class="text-center">{{ $vuetify.lang.t('$vuetify.gooboo.gain') }}</div>
+          <stat-breakdown :base="baseSmoke" name="currencyMiningSmokeGain"></stat-breakdown>
+        </gb-tooltip>
         <template v-if="isDeepest">
           <gb-tooltip v-for="(amount, gas) in gasses" :key="gas" :title-text="$vuetify.lang.t(`$vuetify.currency.mining_${ gas }.name`)">
             <template v-slot:activator="{ on, attrs }">
@@ -257,6 +263,7 @@ export default {
       baseScrap: 'mining/currentBaseScrap',
       ore: 'mining/currentOre',
       smoke: 'mining/currentSmoke',
+      baseSmoke: 'mining/currentBaseSmoke',
       gasses: 'mining/currentGas',
       gasLimit: 'mining/currentGasLimit',
       hitsNeeded: 'mining/hitsNeeded',

--- a/src/store/mining.js
+++ b/src/store/mining.js
@@ -133,8 +133,11 @@ export default {
         graniteBreaksMult: (state, getters) => {
             return Math.pow(2, Math.max(0, Math.floor(logBase(getters.currentBreaks + 1, 10)) - 3));
         },
+        depthBaseSmoke: (state, getters, rootState) => (depth) => {
+            return (rootState.unlock.miningSmoke.use && depth >= 25 && rootState.system.features.mining.currentSubfeature === 1) ? Math.pow(1.05, depth - 25) * 0.01 : 0;
+        },
         depthSmoke: (state, getters, rootState, rootGetters) => (depth) => {
-            return (rootState.unlock.miningSmoke.use && depth >= 25 && rootState.system.features.mining.currentSubfeature === 1) ? rootGetters['mult/get']('currencyMiningSmokeGain', Math.pow(1.05, depth - 25) * 0.01) : 0;
+            return (rootState.unlock.miningSmoke.use && depth >= 25 && rootState.system.features.mining.currentSubfeature === 1) ? rootGetters['mult/get']('currencyMiningSmokeGain', getters.depthBaseSmoke(depth)) : 0;
         },
         depthGasLimit: (state, getters, rootState, rootGetters) => (depth, gas) => {
             return Math.round((depth + 1 - state.gas[gas]) * 100 * Math.pow(rootGetters['mult/get'](`currencyMining${ capitalize(gas) }Increment`, 1), depth - state.gas[gas]));
@@ -174,6 +177,9 @@ export default {
         },
         currentOre: (state, getters) => {
             return getters.depthOre(state.depth);
+        },
+        currentBaseSmoke: (state, getters) => {
+            return getters.depthBaseSmoke(state.depth);
         },
         currentSmoke: (state, getters) => {
             return getters.depthSmoke(state.depth);


### PR DESCRIPTION
I've added stats-breakdown on Mining2 resources tooltips that didn't have them.
![image](https://github.com/user-attachments/assets/95b6a4ae-6cdb-44a0-85ba-233afda6c13e)
![image](https://github.com/user-attachments/assets/8c375d21-b2b7-4e8b-8a96-bb2c7508b0aa)
![image](https://github.com/user-attachments/assets/96e8a5c3-63a5-42c2-9b9a-229996749827)

Linting is OK but there is one error on Unit tests when I run them locally, on something that seems unrelated to what I've changed : stat.test.js

Since this is my first PR, I hope I haven't forgetten anything.